### PR TITLE
Firebaseのトークン認証

### DIFF
--- a/lib/models/auth.dart
+++ b/lib/models/auth.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 
 class Auth extends ChangeNotifier {
   User? _user;
@@ -38,8 +41,16 @@ class Auth extends ChangeNotifier {
                                 password: password,
                               );
       _user = _userCredential.user;
-      _user!.sendEmailVerification(); // 認証メールを送信
-      notifyListeners();
+      final params = {'email': email, 'uid': _user!.uid};
+      String url = 'http://127.0.0.1:3000/api/users';
+      final response = await http.post(Uri.parse(url),
+        body: json.encode(params),
+        headers: {"Content-Type": "application/json"}
+      );
+      if (response.statusCode == 200) {
+        _user!.sendEmailVerification(); // 認証メールを送信
+        notifyListeners();
+      }
       return true;
     } catch (error) {
       rethrow;

--- a/lib/models/auth.dart
+++ b/lib/models/auth.dart
@@ -41,7 +41,8 @@ class Auth extends ChangeNotifier {
                                 password: password,
                               );
       _user = _userCredential.user;
-      final params = {'email': email, 'uid': _user!.uid};
+      final token = await FirebaseAuth.instance.currentUser!.getIdToken();
+      final params = {'token': token, 'user': {'email': email, 'uid': _user!.uid}};
       String url = 'http://127.0.0.1:3000/api/users';
       final response = await http.post(Uri.parse(url),
         body: json.encode(params),

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -1,16 +1,14 @@
 class Post {
   final String content;
   final int genreId;
-  final String userToken;
   final String? createdAt;
 
-  Post({required this.content, required this.genreId, required this.userToken, this.createdAt});
+  Post({required this.content, required this.genreId, this.createdAt});
 
   // API通信時にパラメータをjson形式に変換する
   Map<String, dynamic> toJson() => {
     'content': content,
     'genre_id': genreId,
-    'user_token': userToken,
   };
 
   // APIからのレスポンスをdartで扱える形式に変換する
@@ -19,7 +17,6 @@ class Post {
       Post(
         content: json['content'],
         genreId: json['genre_id'],
-        userToken: json['user_token'],
         createdAt: json['created_at']
       )
     );

--- a/lib/ui/pages/create_memo_page.dart
+++ b/lib/ui/pages/create_memo_page.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:for_the_first_time/models/genre.dart';
 import 'package:reactive_forms/reactive_forms.dart';
@@ -30,12 +31,15 @@ class _CreateMemoPageState extends State<CreateMemoPage> {
 
   Future _createPost(content, genreId) async {
     try {
-      String identityId = 'test';
-      Post newPost = Post(content: content, genreId: genreId, userToken: identityId);
+      Post newPost = Post(content: content, genreId: genreId);
       String url = 'http://127.0.0.1:3000/posts';
+      final token = await FirebaseAuth.instance.currentUser!.getIdToken();
       final response = await http.post(Uri.parse(url),
         body: json.encode(newPost.toJson()),
-        headers: {"Content-Type": "application/json"}
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": 'Bearer $token'
+        }
       );
       if (response.statusCode == 200) {
         // フォームの入力値のリセット

--- a/lib/ui/pages/create_memo_page.dart
+++ b/lib/ui/pages/create_memo_page.dart
@@ -38,7 +38,7 @@ class _CreateMemoPageState extends State<CreateMemoPage> {
         body: json.encode(newPost.toJson()),
         headers: {
           "Content-Type": "application/json",
-          "Authorization": 'Bearer $token'
+          "Authorization": 'Bearer $token' // firebaseのトークン認証
         }
       );
       if (response.statusCode == 200) {

--- a/lib/ui/pages/memo_history.page.dart
+++ b/lib/ui/pages/memo_history.page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:for_the_first_time/ui/components/post_item.dart';
 import '../../models/post.dart';
@@ -28,8 +29,12 @@ class _MemoHistoryPageState extends State<MemoHistoryPage> {
   Future<void> _fetchPosts() async {
     try {
       String url = 'http://127.0.0.1:3000/posts';
+      final token = await FirebaseAuth.instance.currentUser!.getIdToken();
       final response = await http.get(Uri.parse(url),
-        headers: {"Content-Type": "application/json"}
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": 'Bearer $token'
+        }
       );
       if (response.statusCode == 200) {
         // APIから受け取ったjson形式のデータをdartで扱える形式に変換

--- a/lib/ui/pages/memo_history.page.dart
+++ b/lib/ui/pages/memo_history.page.dart
@@ -33,7 +33,7 @@ class _MemoHistoryPageState extends State<MemoHistoryPage> {
       final response = await http.get(Uri.parse(url),
         headers: {
           "Content-Type": "application/json",
-          "Authorization": 'Bearer $token'
+          "Authorization": 'Bearer $token' // firebaseのトークン認証
         }
       );
       if (response.statusCode == 200) {


### PR DESCRIPTION
# 実装概要
- Firebaseで新規登録した際にRailsと通信してユーザーを作成
- メモ投稿、一覧でuser認証情報をサーバーサイドに送信

# 実装の目的
- 特定のユーザーに紐づく投稿のみを表示できるようにするため
- トークン認証をrails側で行うことで安全にするため

# ユーザーストーリー
1. ユーザーが新規登録フォームを送信
2. firebaseと通信してユーザーを作成
3. 無事に作成できればrailsと通信してユーザーを作成
4. DBにusersテーブルを保存
5. トップページに遷移

# 動作確認
## ユーザー新規登録
https://gyazo.com/45eddd837634d8df112472606c6105aa

## メモ投稿・一覧の表示
https://gyazo.com/c92ccb126444e78bc9e6bdfac3510799

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。
## コーディングの品質向上
- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。
## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。
